### PR TITLE
ci: deploy correct directory

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -33,7 +33,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/develop' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: .
+          publish_dir: ./public
           force_orphan: true
           publish_branch: master
 


### PR DESCRIPTION
I thought this was the destination directory, but it turns out it's the
source directory to be published...